### PR TITLE
Update to the latest circe version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,8 +8,8 @@ object Version {
   final val jsonSchemaValidator = "2.2.6"
   final val scalacheck          = "1.13.4"
   final val scalacheckShapeless = "1.1.3"
-  final val circe               = "0.8.0"
-  final val circeYaml           = "0.6.1"
+  final val circe               = "0.9.3"
+  final val circeYaml           = "0.8.0"
 }
 
 object Lib {

--- a/swagger-blocks-json/src/main/scala/swaggerblocks/extensions/json.scala
+++ b/swagger-blocks-json/src/main/scala/swaggerblocks/extensions/json.scala
@@ -8,7 +8,7 @@ object json {
   implicit class ExampleExtension(schemaDef: ApiSchemaDefinition) {
     private val printer = Printer.spaces2.copy(
       preserveOrder = true,
-      dropNullKeys = true,
+      dropNullValues = true,
       colonLeft = ""
     )
 

--- a/swagger-blocks-json/src/main/scala/swaggerblocks/rendering/json/package.scala
+++ b/swagger-blocks-json/src/main/scala/swaggerblocks/rendering/json/package.scala
@@ -16,7 +16,7 @@ package object json extends RenderingPackage with SpecEncoders {
 
     val printer = Printer.noSpaces.copy(
       preserveOrder = true,
-      dropNullKeys = true
+      dropNullValues = true
     )
 
     transformSpec(ApiSpec(root, paths, schemata)).asJson.pretty(printer)
@@ -30,7 +30,7 @@ package object json extends RenderingPackage with SpecEncoders {
 
     val printer = Printer.spaces2.copy(
       preserveOrder = true,
-      dropNullKeys = true,
+      dropNullValues = true,
       colonLeft = ""
     )
 


### PR DESCRIPTION
The latest circe version isn't binary compatible with the version used in swagger-blocks-scala.