### PR TITLE
Cross-compile for Scala 2.13.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ language: scala
 scala:
   - 2.11.11
   - 2.12.2
+  - 2.13.6
 
 jdk:
   - oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ val commonSettings = List(
   Quiet.silenceScalaBinaryVersionWarning,
   scalaVersion := Version.scala,
   crossScalaVersions := Version.crossVersions,
-  version := "0.6.0",
+  version := "0.6.1",
   homepage := Some(url("https://github.com/felixbr/swagger-blocks-scala")),
   organization := "io.github.felixbr",
   licenses := List(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,11 +3,12 @@ import sbt._
 object Version {
   final val scala               = "2.12.6"
   final val scala_2_11          = "2.11.11"
-  final val crossVersions       = List(scala_2_11, scala)
-  final val scalaTest           = "3.0.0"
+  final val scala_2_13          = "2.13.6"
+  final val crossVersions       = List(scala_2_11, scala, scala_2_13)
+  final val scalaTest           = "3.0.9"
   final val jsonSchemaValidator = "2.2.6"
-  final val scalacheck          = "1.13.4"
-  final val scalacheckShapeless = "1.1.3"
+  final val scalacheck          = "1.14.0"
+  final val scalacheckShapeless = "1.2.3"
   final val circe               = "0.9.3"
   final val circeYaml           = "0.8.0"
 }
@@ -16,7 +17,7 @@ object Lib {
   val scalaTest           = "org.scalatest"              %% "scalatest"                 % Version.scalaTest
   val jsonSchemaValidator = "com.github.fge"             % "json-schema-validator"      % Version.jsonSchemaValidator
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % Version.scalacheck
-  val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % Version.scalacheckShapeless
+  val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % Version.scalacheckShapeless
   val circeCore           = "io.circe"                   %% "circe-core"                % Version.circe
   val circeGeneric        = "io.circe"                   %% "circe-generic"             % Version.circe
   val circeParser         = "io.circe"                   %% "circe-parser"              % Version.circe

--- a/swagger-blocks-core/src/test/scala/fixtures/generators.scala
+++ b/swagger-blocks-core/src/test/scala/fixtures/generators.scala
@@ -6,7 +6,7 @@ import swaggerblocks.internal.propertyFormats
 import swaggerblocks.internal.propertyTypes.PropertyType
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalacheck.rng.Seed
 import swaggerblocks._
 import org.scalacheck.Prop._


### PR DESCRIPTION
Hey,

I added cross-compile for Scala 2.13. I had to update 3 libraries used in test, no runtime dependency update was needed.